### PR TITLE
Appliance comment validation

### DIFF
--- a/app/models/appliance_comment.rb
+++ b/app/models/appliance_comment.rb
@@ -2,4 +2,7 @@ class ApplianceComment < ApplicationRecord
   belongs_to :appliance
 
   enum category: %i[fix note problem]
+
+  validates :body, length: {maximum: 500}
+  validates :category, inclusion: {in: ApplianceComment.categories}
 end


### PR DESCRIPTION
Added validation for Appliance comments:
- Validates if category exists
- Checks if comment body is less than 500 characters